### PR TITLE
Defineboard

### DIFF
--- a/package/rpi-firmware/rpi-firmware.mk
+++ b/package/rpi-firmware/rpi-firmware.mk
@@ -37,7 +37,7 @@ define RPI_FIRMWARE_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/lib/libelftoolchain.so
 endef
 endif # INSTALL_VCDBG
-BR2_PACKAGE_RPI_FIRMWARE_X
+
 define RPI_FIRMWARE_INSTALL_IMAGES_CMDS
 	$(INSTALL) -D -m 0644 $(@D)/boot/bootcode.bin $(BINARIES_DIR)/rpi-firmware/bootcode.bin
 	$(INSTALL) -D -m 0644 $(@D)/boot/start*.elf $(BINARIES_DIR)/rpi-firmware/


### PR DESCRIPTION
Approved. Forces existence of boards/mbay/rpi/linux and cleans up garbage.